### PR TITLE
Add Copyright Section to Bottom of Page

### DIFF
--- a/src/Components/Footer.jsx
+++ b/src/Components/Footer.jsx
@@ -38,6 +38,11 @@ const Footer = () => {
           </div>
         </div>
       </div>
+
+      {/* Copyright Section */}
+      <div className="text-center mt-8 text-sm text-gray-500">
+        <p>&copy; {new Date().getFullYear()} Shopy. All rights reserved.</p>
+      </div>
     </footer>
   );
 };


### PR DESCRIPTION
This pull request adds a copyright notice to the footer of the page, ensuring that proper attribution is provided for the Shopy project. The copyright notice includes the current year dynamically generated using JavaScript to keep it up to date. 

Issue : #22 

Before:

![image](https://github.com/mohitparmar1/Shopy/assets/104411008/7ae054a4-e1a5-4379-9238-51eacc1b33d1)


After :

![image](https://github.com/mohitparmar1/Shopy/assets/104411008/ea1e4b5d-943b-4df2-8b87-daf2d48cd8a3)
